### PR TITLE
Update lz4 to v4.3.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels: 
-  jrice_org: jrice_org

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels: 
+  jrice_org: jrice_org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   ignore_run_exports:
     - lz4-c  # [win]
   number: 0
-  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --ignore-installed .
   skip: True  # [py<37]
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
     - setuptools_scm
     - toml
     - wheel
-    - pkgconfig
+    - pkgconfig 1.5.4
     - lz4-c 1.9.4
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - setuptools_scm
+    - setuptools-scm
     - toml
     - wheel
     - pkgconfig

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - setuptools_scm
     - toml
     - wheel
-    - pkgconfig 1.5.4
+    - pkgconfig
     - lz4-c 1.9.4
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ about:
     Provides a Python interface for the LZ4 compression library.
     LZ4 library provides support for three specifications-
     frame format,block format and stream format.
-  doc_url: http://python-lz4.readthedocs.io/en/stable/
+  doc_url: https://python-lz4.readthedocs.io/en/stable/
   dev_url: https://github.com/python-lz4/python-lz4
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "lz4" %}
-{% set version = "3.1.3" %}
-{% set sha256 = "081ef0a3b5941cb03127f314229a1c78bd70c9c220bb3f4dd80033e707feaa18" %}
+{% set version = "4.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -9,13 +8,14 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: e1431d84a9cfb23e6773e72078ce8e65cad6745816d4cbf9ae67da5ea419acda
 
 build:
   ignore_run_exports:
     - lz4-c  # [win]
   number: 0
-  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --ignore-installed .
+  skip: True  # [py<37]
 
 requirements:
   build:
@@ -30,10 +30,16 @@ requirements:
   run:
     - python
     - lz4-c
+    - sphinx >=1.6.0
+    - flake8
 
 test:
   imports:
     - lz4
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/python-lz4/python-lz4
@@ -46,7 +52,6 @@ about:
     LZ4 library provides support for three specifications-
     frame format,block format and stream format.
   doc_url: http://python-lz4.readthedocs.io/en/stable/
-  doc_source_url: https://github.com/python-lz4/python-lz4/blob/master/docs/index.rst
   dev_url: https://github.com/python-lz4/python-lz4
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   ignore_run_exports:
     - lz4-c  # [win]
   number: 0
-  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation --ignore-installed .
+  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed .
   skip: True  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,15 +23,15 @@ requirements:
   host:
     - python
     - pip
-    - pytest-runner
+    - setuptools
     - setuptools_scm
+    - toml
+    - wheel
     - pkgconfig
-    - lz4-c
+    - lz4-c 1.9.4
   run:
     - python
-    - lz4-c
-    - sphinx >=1.6.0
-    - flake8
+    - {{ pin_compatible('lz4-c', max_pin='x.x') }}
 
 test:
   imports:
@@ -51,7 +51,7 @@ about:
     Provides a Python interface for the LZ4 compression library.
     LZ4 library provides support for three specifications-
     frame format,block format and stream format.
-  doc_url: http://python-lz4.readthedocs.io/en/stable/
+  doc_url: http://python-lz4.readthedocs.io
   dev_url: https://github.com/python-lz4/python-lz4
 
 extra:


### PR DESCRIPTION
# Overview

## Links
- [Jira]()
- [Upstream repository](https://github.com/python-lz4/python-lz4/tree/v4.3.2)
- **Related Packages:** Needed for [dask](https://anaconda.atlassian.net/browse/PKG-2148)

--------------------
## Description
- Target channel: `defaults` for Anaconda Distribution 2023.06
### Dependency chain
[`dask-core`](https://github.com/AnacondaRecipes/dask-core-feedstock/pull/31) -> [`distributed`](https://github.com/AnacondaRecipes/distributed-feedstock/pull/29) -> [`dask`](https://github.com/AnacondaRecipes/dask-feedstock/pull/31)
[`lz4`](https://github.com/AnacondaRecipes/lz4-feedstock/pull/3) -> [`dask`](https://github.com/AnacondaRecipes/dask-feedstock/pull/31)

--------------------
### Information checked from upstream: 

- [x] All dependency pinnings match with upstream.
- [x] All URLs are correct.
- [ ] abs.yaml is not present at time of review.

--------------------
### Recipe changes:
- Updated `version` and `sha256`
- Added `--no-build-isolation`
- Support `py>=37` (according to upstream)
- Added `pip` and `pip check`
- Removed `doc_source_url` (according to recipe standards)
- Added following dependencies:
     - `sphinx`
     - `flake8`

--------------------
### Tests conducted/Other misc notes:

- Ran `conda-build` locally and it built successfully
- **_Linter produced errors regarding unpinned packages in the `host` section (unsure if this should be ignored and/or pinned to oldest or latest version available)_**
- Upload to private channel to test compatibility with related packages was successful